### PR TITLE
Update FitZPeak-CMSSW_10_6_18.C

### DIFF
--- a/code/FitZPeak-CMSSW_10_6_18.C
+++ b/code/FitZPeak-CMSSW_10_6_18.C
@@ -52,7 +52,7 @@ void FitZPeak(bool save = false, vector<string> formats = {".eps"}){
    TF1 *func = new TF1("mybw",mybw,massMIN, massMAX,3);
    func->SetParameter(0,1.0);   func->SetParName(0,"const");
    func->SetParameter(2,5.0);     func->SetParName(1,"sigma");
-   func->SetParameter(1,95.0);    func->SetParName(2,"mean");
+   func->SetParameter(1,94.0);    func->SetParName(2,"mean");
    
    Z_mass->Fit("mybw","QR");
    TF1 *fit = Z_mass->GetFunction("mybw");


### PR DESCRIPTION
Fixing mean in BW fit to make the fit converge.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
