### PR TITLE
Removed whitespace to show as a header2

### DIFF
--- a/_episodes/03-CMSDataAnalysisSchoolPreExerciseThirdSet.md
+++ b/_episodes/03-CMSDataAnalysisSchoolPreExerciseThirdSet.md
@@ -811,7 +811,7 @@ We will make another CRAB config file: `crabConfig_data_slimMiniAOD.py`. Copy it
 
  Most of this file should be familiar by now, but a few things may be new. The `runRange` parameter is used to further limit your jobs to a range of what is in the `lumiMask` file. This is needed if your two input datasets overlap. That way you can control which events come from which datasets. Instructions how to do this are at [https://twiki.cern.ch/twiki/bin/viewauth/CMS/PdmVAnalysisSummaryTable](https://twiki.cern.ch/twiki/bin/viewauth/CMS/PdmVAnalysisSummaryTable). You can find the year specific instructions by clicking any of the links at the bottom.
 
- ## Run CRAB
+## Run CRAB
 
  Now go through the same process for this config file. You submit it with
 


### PR DESCRIPTION
Basically the whitespace did not allow the Header 2 display correctly.